### PR TITLE
Entry translation revised and from now can be explicitly set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+## 0.2.4
+
+### Features
+
+### Explicit direction of translation animation
+`EKAttributes.Animation.Translate` is added an `anchorPosition: AnchorPosition` property:
+
+That means that an entry can translate from the top and exit from the bottom, and vice versa.
+
+```Swift
+/** Describes the anchor position */
+public enum AnchorPosition {
+
+    /** Top position - the entry shows from top or exits towards the top */
+    case top
+
+    /** Bottom position - the entry shows from bottom or exits towards the bottom */
+    case bottom
+
+    /** Automatic position - the entry shows and exits according to EKAttributes.Position value. If the position of the entry is top, bottom, the entry's translation anchor is top, bottom - respectively.*/
+    case automatic
+}
+```
+
+`anchorPosition` is determined the direction of the translation animation and is `.automatic` by default, meaning that the anchor is set automatically according to its position - if the position (`EKAttributes.Position`) is `.top` / `bottom`, then the entry enters and exit from the top / bottom edge.
+
 ## 0.2.3
 
 ### Features
 
-#### Status Bar Revised
+#### Status bar revised
 * Instead of assigning the `UIStatusBarStyle`, use `EKAttributes.StatusBar` to define the status bar.
 * The benefit is an absolute control over the status bar appearance.
 * New statuses:
@@ -47,4 +73,3 @@ if SwiftEntryKit.isCurrentlyDisplaying {
 #### Naming
 
 `EKProperty.LabelStyle` replaced `EKProperty.Label`.
-

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.2.3):
+  - SwiftEntryKit (0.2.4):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 429c4a7cba7bdd4249fb3218401229335bb914b4
+  SwiftEntryKit: df453c5fdab60eeb1c1974d74c91cf41edba9d30
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.2.3"
+    "tag": "0.2.4"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.2.3):
+  - SwiftEntryKit (0.2.4):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 429c4a7cba7bdd4249fb3218401229335bb914b4
+  SwiftEntryKit: df453c5fdab60eeb1c1974d74c91cf41edba9d30
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.3</string>
+  <string>0.2.4</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/SwiftEntryKit/InAppPresets/PresetsData/PresetsDataSource.swift
+++ b/Example/SwiftEntryKit/InAppPresets/PresetsData/PresetsDataSource.swift
@@ -271,13 +271,12 @@ struct PresetsDataSource {
         description = .init(with: attributes, title: "Pop Up II", description: descriptionString, thumb: descriptionThumb)
         presets.append(description)
         
-        
         // Preset III
         attributes = bottomAlertAttributes
         attributes.scroll = .edgeCrossingDisabled(swipeable: true)
         attributes.entranceAnimation = .init(translate: .init(duration: 0.5, spring: .init(damping: 1, initialVelocity: 0)))
         attributes.entryBackground = .gradient(gradient: .init(colors: [EKColor.LightPink.first, EKColor.LightPink.last], startPoint: .zero, endPoint: CGPoint(x: 1, y: 1)))
-        attributes.positionConstraints = .full
+        attributes.positionConstraints = .fullWidth
         attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
         attributes.roundCorners = .top(radius: 20)
         descriptionString = "Bottom toast popup with gradient background"
@@ -365,8 +364,8 @@ struct PresetsDataSource {
         attributes.position = .center
         attributes.displayDuration = .infinity
         
-        attributes.entranceAnimation = .init(translate: .init(duration: 0.65, spring: .init(damping: 1, initialVelocity: 0)))
-        attributes.exitAnimation = .init(translate: .init(duration: 0.65, spring: .init(damping: 1, initialVelocity: 0)))
+        attributes.entranceAnimation = .init(translate: .init(duration: 0.65, anchorPosition: .bottom,  spring: .init(damping: 1, initialVelocity: 0)))
+        attributes.exitAnimation = .init(translate: .init(duration: 0.65, anchorPosition: .top, spring: .init(damping: 1, initialVelocity: 0)))
         attributes.popBehavior = .animated(animation: .init(translate: .init(duration: 0.65, spring: .init(damping: 1, initialVelocity: 0))))
         
         attributes.entryInteraction = .absorbTouches

--- a/Example/SwiftEntryKit/Playground/PlaygroundViewController.swift
+++ b/Example/SwiftEntryKit/Playground/PlaygroundViewController.swift
@@ -15,7 +15,7 @@ class PlaygroundViewController: UIViewController {
     
     private lazy var attributesWrapper: EntryAttributeWrapper = {
         var attributes = EKAttributes()
-        attributes.positionConstraints = .full
+        attributes.positionConstraints = .fullWidth
         attributes.hapticFeedbackType = .success
         attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
         attributes.entryBackground = .visualEffect(style: .light)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.2.3'
+pod 'SwiftEntryKit', '0.2.4'
 ```
 
 Then, run the following command:
@@ -137,7 +137,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.2.3
+github "huri000/SwiftEntryKit" == 0.2.4
 ```
 
 ## Usage
@@ -405,15 +405,19 @@ attributes.border = .none
 ```
 
 #### Animations
-Describes how the entry animates into and out of the screen. Each animation object can have 3 types of animations at the same time. You can combine animation to a complex one.
+Describes how the entry animates into and out of the screen. 
 
-Example for a complex entrance animation that contains translation of the entry using spring animation, scale in and even fade in.
+* Each animation descriptor can have up to 3 types of animations at the same time. Those can be combined to a single complex one!
+* Translation animation anchor can be explicitly set but it receives a default value according to position of the entry.
+
+Example for _translation_ from top with spring, _scale_ in and even _fade in_ as a single entrance animation:
 ```Swift
 attributes.entranceAnimation = .init(
-                 translate: .init(duration: 0.7, spring: .init(damping: 1, initialVelocity: 0)), 
+                 translate: .init(duration: 0.7, anchorPosition: .top, spring: .init(damping: 1, initialVelocity: 0)), 
                  scale: .init(from: 0.6, to: 1, duration: 0.7), 
                  fade: .init(from: 0.8, to: 1, duration: 0.3))
 ```
+
 #### Pop Behavior
 Describes the entry behavior when it's being popped (dismissed by an entry with equal / higher display-priority.
 
@@ -500,7 +504,7 @@ var attributes = EKAttributes.topFloat
 attributes.entryBackground = .gradient(gradient: .init(colors: [.red, .green], startPoint: .zero, endPoint: CGPoint(x: 1, y: 1)))
 attributes.popBehavior = .animated(animation: .init(translate: .init(duration: 0.3), scale: .init(from: 1, to: 0.7, duration: 0.7)))
 attributes.shadow = .active(with: .init(color: .black, opacity: 0.5, radius: 10, offset: .zero))
-attributes.statusBarStyle = .default
+attributes.statusBar = .dark
 attributes.scroll = .enabled(swipeable: true, pullbackAnimation: .jolt)
 attributes.positionConstraints.maxSize = .init(width: .constant(value: UIScreen.main.minEdge), height: .intrinsic)
 

--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import QuickLayout
 
 protocol EntryContentViewDelegate: class {
     func changeToActive(withAttributes attributes: EKAttributes)
@@ -18,7 +19,18 @@ class EKContentView: UIView {
     enum OutTranslation {
         case exit
         case pop
-        case swipe
+        case swipeDown
+        case swipeUp
+    }
+    
+    struct OutTranslationAnchor {
+        var messageOut: QLAttribute
+        var screenOut: QLAttribute
+        
+        init(_ messageOut: QLAttribute, to screenOut: QLAttribute) {
+            self.messageOut = messageOut
+            self.screenOut = screenOut
+        }
     }
     
     // MARK: Props
@@ -29,9 +41,10 @@ class EKContentView: UIView {
     // Constraints and Offsets
     private var entranceOutConstraint: NSLayoutConstraint!
     private var exitOutConstraint: NSLayoutConstraint!
+    private var swipeDownOutConstraint: NSLayoutConstraint!
+    private var swipeUpOutConstraint: NSLayoutConstraint!
     private var popOutConstraint: NSLayoutConstraint!
     private var inConstraint: NSLayoutConstraint!
-    private var outConstraint: NSLayoutConstraint!
     private var resistanceConstraint: NSLayoutConstraint!
     private var inKeyboardConstraint: NSLayoutConstraint!
     
@@ -92,10 +105,8 @@ class EKContentView: UIView {
         
         // Determine the layout entrance type according to the entry type
         let messageInAnchor: NSLayoutAttribute
-        let screenOutAnchor: NSLayoutAttribute
-        let messageOutAnchor: NSLayoutAttribute
+        
         inOffset = 0
-        var outOffset: CGFloat = 0
         
         var totalEntryHeight: CGFloat = 0
         
@@ -115,27 +126,16 @@ class EKContentView: UIView {
         
         switch attributes.position {
         case .top:
-            screenOutAnchor = .top
-            messageOutAnchor = .bottom
             messageInAnchor = .top
-            
             inOffset = overrideSafeArea ? 0 : safeAreaInsets.top
             inOffset += attributes.positionConstraints.verticalOffset
-            outOffset = -safeAreaInsets.top
-            
             spacerView?.layout(.bottom, to: .top, of: self)
         case .bottom:
-            screenOutAnchor = .bottom
-            messageOutAnchor = .top
             messageInAnchor = .bottom
-            
             inOffset = overrideSafeArea ? 0 : -safeAreaInsets.bottom
             inOffset -= attributes.positionConstraints.verticalOffset
-            
             spacerView?.layout(.top, to: .bottom, of: self)
         case .center:
-            screenOutAnchor = .bottom
-            messageOutAnchor = .top
             messageInAnchor = .centerY
         }
         
@@ -144,29 +144,11 @@ class EKContentView: UIView {
         contentView.layoutToSuperview(.left, .right, .top, .bottom)
         contentView.layoutToSuperview(.width, .height)
         
-        // Setup out constraint, capture pre calculated offsets and attributes
-        let setupOutConstraint = { (animation: EKAttributes.Animation, priority: UILayoutPriority) -> NSLayoutConstraint in
-            let constraint: NSLayoutConstraint
-            if animation.containsTranslation {
-                constraint = self.layout(messageOutAnchor, to: screenOutAnchor, of: self.superview!, offset: outOffset, priority: priority)!
-            } else {
-                constraint = self.layout(to: messageInAnchor, of: self.superview!, offset: self.inOffset, priority: priority)!
-            }
-            return constraint
-        }
-        
-        if case .animated(animation: let animation) = attributes.popBehavior {
-            popOutConstraint = setupOutConstraint(animation, .defaultLow)
-        } else {
-            popOutConstraint = layout(to: messageInAnchor, of: superview!, offset: inOffset, priority: .defaultLow)!
-        }
+        inConstraint = layout(to: messageInAnchor, of: superview!, offset: inOffset, priority: .defaultLow)
         
         // Set position constraints
-        entranceOutConstraint = setupOutConstraint(attributes.entranceAnimation, .must)
-        exitOutConstraint = setupOutConstraint(attributes.exitAnimation, .defaultLow)
-        inConstraint = layout(to: messageInAnchor, of: superview!, offset: inOffset, priority: .defaultLow)
-        outConstraint = layout(messageOutAnchor, to: screenOutAnchor, of: superview!, offset: outOffset, priority: .defaultLow)
-
+        setupOutConstraints(messageInAnchor: messageInAnchor)
+        
         totalTranslation = inOffset
         switch attributes.position {
         case .top:
@@ -186,6 +168,45 @@ class EKContentView: UIView {
             break
         }
     }
+    
+    private func setupOutConstraint(animation: EKAttributes.Animation?, messageInAnchor: QLAttribute, priority: QLPriority) -> NSLayoutConstraint {
+        let constraint: NSLayoutConstraint
+        if let translation = animation?.translate {
+            var anchor: OutTranslationAnchor
+            switch translation.anchorPosition {
+            case .top:
+                anchor = OutTranslationAnchor(.bottom, to: .top)
+            case .bottom:
+                anchor = OutTranslationAnchor(.top, to: .bottom)
+            case .automatic where attributes.position.isTop:
+                anchor = OutTranslationAnchor(.bottom, to: .top)
+            case .automatic: // attributes.position.isBottom:
+                anchor = OutTranslationAnchor(.top, to: .bottom)
+            }
+            constraint = layout(anchor.messageOut, to: anchor.screenOut, of: superview!, priority: priority)!
+        } else {
+            constraint = layout(to: messageInAnchor, of: superview!, offset: inOffset, priority: priority)!
+        }
+        return constraint
+    }
+    
+    // Setup out constraints - taking into account the full picture and all the possible use-cases
+    private func setupOutConstraints(messageInAnchor: QLAttribute) {
+        
+        // Setup entrance and exit out constraints
+        entranceOutConstraint = setupOutConstraint(animation: attributes.entranceAnimation, messageInAnchor: messageInAnchor, priority: .must)
+        exitOutConstraint = setupOutConstraint(animation: attributes.exitAnimation, messageInAnchor: messageInAnchor, priority: .defaultLow)
+        swipeDownOutConstraint = layout(.top, to: .bottom, of: superview!, priority: .defaultLow)!
+        swipeUpOutConstraint = layout(.bottom, to: .top, of: superview!, priority: .defaultLow)!
+        
+        // Setup pop out constraint
+        var popAnimation: EKAttributes.Animation?
+        if case .animated(animation: let animation) = attributes.popBehavior {
+            popAnimation = animation
+        }
+        popOutConstraint = setupOutConstraint(animation: popAnimation, messageInAnchor: messageInAnchor, priority: .defaultLow)
+    }
+    
     
     private func setupSize() {
         
@@ -389,8 +410,10 @@ class EKContentView: UIView {
             exitOutConstraint.priority = .must
         case .pop:
             popOutConstraint.priority = .must
-        case .swipe:
-            outConstraint.priority = .must
+        case .swipeUp:
+            swipeUpOutConstraint.priority = .must
+        case .swipeDown:
+            swipeDownOutConstraint.priority = .must
         }
         superview?.layoutIfNeeded()
     }
@@ -599,18 +622,18 @@ extension EKContentView {
         duration = min(0.7, duration)
         
         if attributes.scroll.isSwipeable && testSwipeVelocity(with: velocity) && testSwipeInConstraint() {
-            stretchOut(duration: duration)
+            stretchOut(usingSwipe: velocity > 0 ? .swipeDown : .swipeUp, duration: duration)
         } else {
             animateRubberBandPullback()
         }
     }
     
-    private func stretchOut(duration: TimeInterval) {
+    private func stretchOut(usingSwipe type: OutTranslation, duration: TimeInterval) {
         outDispatchWorkItem?.cancel()
         entryDelegate?.changeToInactive(withAttributes: attributes)
         
         UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 4, options: [.allowUserInteraction, .beginFromCurrentState], animations: {
-            self.translateOut(withType: .swipe)
+            self.translateOut(withType: type)
         }, completion: { finished in
             self.removeFromSuperview(keepWindow: false)
         })

--- a/Source/Model/EntryAttributes/EKAttributes+Animation.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+Animation.swift
@@ -28,9 +28,14 @@ public extension EKAttributes {
     
         /** Describes properties for a spring animation that can be performed on the entry */
         public struct Spring {
-            public let damping: CGFloat
-            public let initialVelocity: CGFloat
             
+            /** The dampic of the spring animation */
+            public var damping: CGFloat
+            
+            /** The initial velocity of the spring animation */
+            public var initialVelocity: CGFloat
+            
+            /** Initializer */
             public init(damping: CGFloat, initialVelocity: CGFloat) {
                 self.damping = damping
                 self.initialVelocity = initialVelocity
@@ -39,12 +44,23 @@ public extension EKAttributes {
 
         /** Describes an animation with range */
         public struct RangeAnimation: EKRangeAnimation {
+            
+            /** The duration of the range animation */
             public var duration: TimeInterval
+            
+            /** The delay of the range animation */
             public var delay: TimeInterval
+            
+            /** The start value of the range animation (e.g. alpha, scale) */
             public var start: CGFloat
+            
+            /** The end value of the range animation (e.g. alpha, scale) */
             public var end: CGFloat
+            
+            /** The spring of the animation */
             public var spring: Spring?
             
+            /** Initializer */
             public init(from start: CGFloat, to end: CGFloat, duration: TimeInterval, delay: TimeInterval = 0, spring: Spring? = nil) {
                 self.start = start
                 self.end = end
@@ -56,13 +72,37 @@ public extension EKAttributes {
         
         /** Describes translation animation */
         public struct Translate: EKAnimation {
+            
+            /** Describes the anchor position */
+            public enum AnchorPosition {
+                
+                /** Top position - the entry shows from top or exits towards the top */
+                case top
+                
+                /** Bottom position - the entry shows from bottom or exits towards the bottom */
+                case bottom
+                
+                /** Automatic position - the entry shows and exits according to EKAttributes.Position value. If the position of the entry is top, bottom, the entry's translation anchor is top, bottom - respectively.*/
+                case automatic
+            }
+            
+            /** Animation duration */
             public var duration: TimeInterval
+            
+            /** Animation delay */
             public var delay: TimeInterval
+            
+            /** To where OR from the entry is animated */
+            public var anchorPosition: AnchorPosition
+            
+            /** Optional translation spring */
             public var spring: Spring?
 
-            public init(duration: TimeInterval, delay: TimeInterval = 0, spring: Spring? = nil) {
-                self.delay = delay
+            /** Initializer */
+            public init(duration: TimeInterval, anchorPosition: AnchorPosition = .automatic, delay: TimeInterval = 0, spring: Spring? = nil) {
+                self.anchorPosition = anchorPosition
                 self.duration = duration
+                self.delay = delay
                 self.spring = spring
             }
         }
@@ -76,36 +116,42 @@ public extension EKAttributes {
         /** Fade animation prop */
         public var fade: RangeAnimation?
         
+        /** Does the animation contains translation */
         public var containsTranslation: Bool {
             return translate != nil
         }
         
+        /** Does the animation contains scale */
         public var containsScale: Bool {
             return scale != nil
         }
         
+        /** Does the animation contains fade */
         public var containsFade: Bool {
             return fade != nil
         }
         
+        /** Does the animation contains any animation whatsoever */
         public var containsAnimation: Bool {
             return containsTranslation || containsScale || containsFade
         }
         
+        /** Returns the maximum delay amongst all animations */
         public var maxDelay: TimeInterval {
             return max(translate?.delay ?? 0, max(scale?.delay ?? 0, fade?.delay ?? 0))
         }
         
+        /** Returns the maximum duration amongst all animations */
         public var maxDuration: TimeInterval {
             return max(translate?.duration ?? 0, max(scale?.duration ?? 0, fade?.duration ?? 0))
         }
         
-        // Returns max duration + max delay
+        /** Returns the maximum (duration+delay) amongst all animations */
         public var totalDuration: TimeInterval {
             return maxDelay + maxDuration
         }
         
-        // Class vars
+        /** Returns the maximum (duration+delay) amongst all animations */
         public static var translation: Animation {
             return Animation(translate: .init(duration: 0.3))
         }
@@ -115,6 +161,7 @@ public extension EKAttributes {
             return Animation()
         }
         
+        /** Initializer */
         public init(translate: Translate? = nil, scale: RangeAnimation? = nil, fade: RangeAnimation? = nil) {
             self.translate = translate
             self.scale = scale

--- a/Source/Model/EntryAttributes/EKAttributes+PositionConstraints.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+PositionConstraints.swift
@@ -32,29 +32,6 @@ public extension EKAttributes {
             }
         }
         
-        /** Describes the size of the entry */
-        public struct Size {
-            
-            /** Describes a width constraint */
-            public var width: Edge
-            
-            /** Describes a height constraint */
-            public var height: Edge
-            
-            public init(width: Edge, height: Edge) {
-                self.width = width
-                self.height = height
-            }
-            
-            public static var intrinsic: Size {
-                return Size(width: .intrinsic, height: .intrinsic)
-            }
-            
-            public static var sizeToWidth: Size {
-                return Size(width: .offset(value: 0), height: .intrinsic)
-            }
-        }
-        
         /** Describes an edge constraint of the entry */
         public enum Edge {
             
@@ -69,6 +46,42 @@ public extension EKAttributes {
             
             /** Unspecified edge length */
             case intrinsic
+            
+            /** Edge totally filled */
+            public static var fill: Edge {
+                return .offset(value: 0)
+            }
+        }
+        
+        /** Describes the size of the entry */
+        public struct Size {
+            
+            /** Describes a width constraint */
+            public var width: Edge
+            
+            /** Describes a height constraint */
+            public var height: Edge
+            
+            /** Initializer */
+            public init(width: Edge, height: Edge) {
+                self.width = width
+                self.height = height
+            }
+            
+            /** The content's size. Entry's content view must have tight constraints */
+            public static var intrinsic: Size {
+                return Size(width: .intrinsic, height: .intrinsic)
+            }
+            
+            /** The content's size. Entry's content view must have tight constraints */
+            public static var sizeToWidth: Size {
+                return Size(width: .offset(value: 0), height: .intrinsic)
+            }
+            
+            /** Screen size, without horizontal or vertical offset */
+            public static var screen: Size {
+                return Size(width: .fill, height: .fill)
+            }
         }
         
         /** The relation to the keyboard's top and the screen's top while it is opened */
@@ -90,7 +103,7 @@ public extension EKAttributes {
                 
                 /** None offset */
                 public static var none: Offset {
-                    return .init()
+                    return Offset()
                 }
             }
             
@@ -133,14 +146,19 @@ public extension EKAttributes {
             return verticalOffset > 0
         }
         
-        /** Returns a full entry (Toast-Like) */
-        public static var full: PositionConstraints {
+        /** Returns a floating entry (float-like) */
+        public static var float: PositionConstraints {
+            return PositionConstraints(verticalOffset: 10, size: .init(width: .offset(value: 20), height: .intrinsic))
+        }
+        
+        /** A full width entry (toast-like) */
+        public static var fullWidth: PositionConstraints {
             return PositionConstraints(verticalOffset: 0, size: .sizeToWidth)
         }
         
-        /** Returns a floating entry (Float-Like) */
-        public static var float: PositionConstraints {
-            return PositionConstraints(verticalOffset: 10, size: .init(width: .offset(value: 20), height: .intrinsic))
+        /** A full screen entry - fills the entire screen, modal-like */
+        public static var fullScreen: PositionConstraints {
+            return PositionConstraints(verticalOffset: 0, size: .screen)
         }
         
         /** Initialize with default parameters */

--- a/Source/Model/EntryAttributes/EKAttributes+Presets.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+Presets.swift
@@ -15,7 +15,7 @@ public extension EKAttributes {
     /** Toast preset - The frame fills margins and safe area is filled with background view */
     public static var toast: EKAttributes {
         var attributes = EKAttributes()
-        attributes.positionConstraints = .full
+        attributes.positionConstraints = .fullWidth
         attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
         attributes.windowLevel = .statusBar
         attributes.scroll = .edgeCrossingDisabled(swipeable: true)

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.2.3'
+  s.version = '0.2.4'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
### Goals 🥅
Enable developers to explicitly set entry translation direction.

### Implementation Details ✏️
- Added AnchorPosition to EKAttributes.Translate
- Set default value to .automatic (backward compatibility).
- Modified the constraints and priorities in EKContentView to support a new infrastructure.

### Testing Details 🔍
Using the presets in the example project.