### PR TITLE
Bug Fix: EKAlertMessageView fail to layout all of the ButtonContents …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+## 0.3.2
+
+### Bug Fixes
+
+* [EKAlertMessageView fail to layout all of the ButtonContents inside EKAlertMessage #41](https://github.com/huri000/SwiftEntryKit/issues/41)
+
 ## 0.3.1
 
 ### Features

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.3.1):
+  - SwiftEntryKit (0.3.2):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 3ed2ea7496d22dfba4693f9029a0c217c1915d76
+  SwiftEntryKit: e2e36ab4cb060d0ce190b4a399a5bca26dcc2bad
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,12 +1,12 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
   },
   "requires_arc": true,
-  "description": "SwiftEntryKit is a banner presenter library for iOS. It can be used to easily display pop-ups and notification-like views within your iOS apps. SwiftEntryKit is highly customizable but also offsers a bunch of beatiful presets that can be themed with your app fonts and colors.",
+  "description": "SwiftEntryKit is a banner presenter library for iOS. It can be used to easily display pop-ups and notification-like views within your iOS apps. SwiftEntryKit is highly customizable but also offers a bunch of beautiful presets that can be themed with your app fonts and colors.",
   "homepage": "https://github.com/huri000/SwiftEntryKit",
   "license": {
     "type": "MIT",
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.3.1"
+    "tag": "0.3.2"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.3.1):
+  - SwiftEntryKit (0.3.2):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 3ed2ea7496d22dfba4693f9029a0c217c1915d76
+  SwiftEntryKit: e2e36ab4cb060d0ce190b4a399a5bca26dcc2bad
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.3.1</string>
+  <string>0.3.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.3.1'
+pod 'SwiftEntryKit', '0.3.2'
 ```
 
 Then, run the following command:
@@ -150,7 +150,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.3.1
+github "huri000/SwiftEntryKit" == 0.3.2
 ```
 
 ## Usage

--- a/Source/MessageViews/MessagesUtils/EKButtonBarView.swift
+++ b/Source/MessageViews/MessagesUtils/EKButtonBarView.swift
@@ -85,6 +85,7 @@ public class EKButtonBarView: UIView {
         guard !buttons.isEmpty else {
             return
         }
+        Array(buttons.dropFirst()).layout(.height, to: buttons.first!)
         buttons.layoutToSuperview(axis: oppositeAxis)
         buttons.spread(spreadAxis, stretchEdgesToSuperview: true)
         buttons.layout(relativeEdge, to: self, ratio: buttonEdgeRatio, priority: .must)

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,14 +8,14 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.3.1'
+  s.version = '0.3.2'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'
   s.requires_arc = true
 
 s.description      = <<-DESC
-SwiftEntryKit is a banner presenter library for iOS. It can be used to easily display pop-ups and notification-like views within your iOS apps. SwiftEntryKit is highly customizable but also offsers a bunch of beautiful presets that can be themed with your app fonts and colors.
+SwiftEntryKit is a banner presenter library for iOS. It can be used to easily display pop-ups and notification-like views within your iOS apps. SwiftEntryKit is highly customizable but also offers a bunch of beautiful presets that can be themed with your app fonts and colors.
 DESC
   s.homepage         = 'https://github.com/huri000/SwiftEntryKit'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
…inside EKAlertMessage #41

### Issue Link 🔗
[EKAlertMessageView fail to layout all of the ButtonContents inside EKAlertMessage #41 ](https://github.com/huri000/SwiftEntryKit/issues/41)

### Goals 🥅
Fixed the bug that is described in the issue above

### Implementation Details ✏️
Force equal height of all the buttons in EKButtonBarView using QuickLayout.