### PR TITLE
 Applying the action in the "parent view" at the end of the gesture instead of the beginning

### DIFF
--- a/Source/Infra/EKRootViewController.swift
+++ b/Source/Infra/EKRootViewController.swift
@@ -145,7 +145,7 @@ class EKRootViewController: UIViewController {
 
 extension EKRootViewController {
     
-    override public func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         switch lastAttributes.screenInteraction.defaultAction {
         case .dismissEntry:
             lastEntry?.animateOut(pushOut: false)

--- a/Source/Infra/EKRootViewController.swift
+++ b/Source/Infra/EKRootViewController.swift
@@ -145,7 +145,7 @@ class EKRootViewController: UIViewController {
 
 extension EKRootViewController {
     
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         switch lastAttributes.screenInteraction.defaultAction {
         case .dismissEntry:
             lastEntry?.animateOut(pushOut: false)


### PR DESCRIPTION
### Issue Link 🔗
if we put `screenInteraction` to dismiss and we start touching the screen the popup dismiss immediately

### Goals 🥅
Dismiss the popup at the end of the user touch instead of the beginning 

### Implementation Details ✏️
I did a quick fix by replacing `touchesBegan` by `touchesEnded`
May be we should improve that and handle only tap gesture 
