### PR TITLE
Bugfix/ios9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+## 0.5.7
+
+### Changes:
+
+Dismiss entries using `touchesEnded` instead of `touchesBegan`. 
+
+### Issues Fixed
+
+[Deployment target is 9.3, not 9.0 #78](https://github.com/huri000/SwiftEntryKit/issues/78)
+
 ## 0.5.6
 
 ### Bug Fixes:

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.5.6):
+  - SwiftEntryKit (0.5.7):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: e4cbd2d46508a9db957cb1b09cb1520f53fb965f
+  SwiftEntryKit: d91cffd71249683a4a9872ef4570e87638e1746d
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.5.6"
+    "tag": "0.5.7"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.5.6):
+  - SwiftEntryKit (0.5.7):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: e4cbd2d46508a9db957cb1b09cb1520f53fb965f
+  SwiftEntryKit: d91cffd71249683a4a9872ef4570e87638e1746d
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.5.6</string>
+  <string>0.5.7</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/SwiftEntryKit.xcodeproj/project.pbxproj
+++ b/Example/SwiftEntryKit.xcodeproj/project.pbxproj
@@ -1154,6 +1154,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = SwiftEntryKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.huri.SwiftEntryKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1190,6 +1191,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = SwiftEntryKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.huri.SwiftEntryKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1247,7 +1249,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1294,7 +1296,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1316,6 +1318,7 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftEntryKit\"",
 				);
 				INFOPLIST_FILE = SwiftEntryKit/DemoAppInfo.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -1338,6 +1341,7 @@
 					"\"${PODS_CONFIGURATION_BUILD_DIR}/SwiftEntryKit\"",
 				);
 				INFOPLIST_FILE = SwiftEntryKit/DemoAppInfo.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.5.6'
+pod 'SwiftEntryKit', '0.5.7'
 ```
 
 Then, run the following command:
@@ -155,7 +155,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.5.6
+github "huri000/SwiftEntryKit" == 0.5.7
 ```
 
 ## Usage

--- a/Source/Infra/EKRootViewController.swift
+++ b/Source/Infra/EKRootViewController.swift
@@ -145,7 +145,7 @@ class EKRootViewController: UIViewController {
 
 extension EKRootViewController {
     
-    override public func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         switch lastAttributes.screenInteraction.defaultAction {
         case .dismissEntry:
             lastEntry?.animateOut(pushOut: false)

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.5.6'
+  s.version = '0.5.7'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
### Issue Link 🔗
[Deployment target is 9.3, not 9.0 #78](https://github.com/huri000/SwiftEntryKit/issues/78)

### Goals 🥅
Support iOS 9 for Carthage (It has been 9.3)

### Implementation Details ✏️
Lowered deployment target.
