### PR TITLE
Ensure willDisappear closure is called before removing contentView

### DIFF
--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -460,6 +460,9 @@ class EKContentView: UIView {
     func removePromptly(keepWindow: Bool = true) {
         outDispatchWorkItem?.cancel()
         entryDelegate?.changeToInactive(withAttributes: attributes, pushOut: false)
+        
+        // Execute willDisappear action if needed
+        self.contentView.content.attributes.lifecycleEvents.willDisappear?()
         removeFromSuperview(keepWindow: keepWindow)
     }
     
@@ -666,6 +669,8 @@ extension EKContentView {
         UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 4, options: [.allowUserInteraction, .beginFromCurrentState], animations: {
             self.translateOut(withType: type)
         }, completion: { finished in
+            // Execute willDisappear action if needed
+            self.contentView.content.attributes.lifecycleEvents.willDisappear?()
             self.removeFromSuperview(keepWindow: false)
         })
     }


### PR DESCRIPTION
A very simple fix, solving issue #85.

### Issue Link 🔗
 Issue #85 - willDisappear closure not called in some cases

### Implementation Details ✏️
- Added calls to `lifecycleEvents.willDisappear()` in the `removePromptly(keepWindow:)` and `stretchOut(usingSwipe:, duration:)` functions of `EKContentView`