### PR TITLE
Bugfix/entry will disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+
+## 0.5.9
+
+### Issue [#85](https://github.com/huri000/SwiftEntryKit/pull/86)
+Lifecycle event `willDisappear` does not get called on swipe and prompt removeal of entry.
+
 ## 0.5.8
 
 ### Issues Resolved:

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.5.8):
+  - SwiftEntryKit (0.5.9):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 0b1c33fcf866625a7bbb7fda2def2a0a53b7e6e6
+  SwiftEntryKit: 25030c650d0e21dfbfd2906965d32d3728fc5dc1
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.5.8"
+    "tag": "0.5.9"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.5.8):
+  - SwiftEntryKit (0.5.9):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 0b1c33fcf866625a7bbb7fda2def2a0a53b7e6e6
+  SwiftEntryKit: 25030c650d0e21dfbfd2906965d32d3728fc5dc1
 
 PODFILE CHECKSUM: edd6c2af5cc390dbf823427759474ab6c303ec9e
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.5.8</string>
+  <string>0.5.9</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.5.8'
+pod 'SwiftEntryKit', '0.5.9'
 ```
 
 Then, run the following command:
@@ -155,7 +155,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.5.8
+github "huri000/SwiftEntryKit" == 0.5.9
 ```
 
 ## Usage

--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -460,9 +460,7 @@ class EKContentView: UIView {
     func removePromptly(keepWindow: Bool = true) {
         outDispatchWorkItem?.cancel()
         entryDelegate?.changeToInactive(withAttributes: attributes, pushOut: false)
-        
-        // Execute willDisappear action if needed
-        self.contentView.content.attributes.lifecycleEvents.willDisappear?()
+        contentView.content.attributes.lifecycleEvents.willDisappear?()
         removeFromSuperview(keepWindow: keepWindow)
     }
     
@@ -665,12 +663,10 @@ extension EKContentView {
     private func stretchOut(usingSwipe type: OutTranslation, duration: TimeInterval) {
         outDispatchWorkItem?.cancel()
         entryDelegate?.changeToInactive(withAttributes: attributes, pushOut: false)
-        
+        contentView.content.attributes.lifecycleEvents.willDisappear?()
         UIView.animate(withDuration: duration, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 4, options: [.allowUserInteraction, .beginFromCurrentState], animations: {
             self.translateOut(withType: type)
         }, completion: { finished in
-            // Execute willDisappear action if needed
-            self.contentView.content.attributes.lifecycleEvents.willDisappear?()
             self.removeFromSuperview(keepWindow: false)
         })
     }

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.5.8'
+  s.version = '0.5.9'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
### Issue Link 🔗
[Ensure willDisappear closure is called before removing contentView #86](https://github.com/huri000/SwiftEntryKit/pull/86).

A slight fix for the pull request - `willDisappear` should be executed before the swipe translation. The line moved from the completion closure of the animation to before `UIView.animate`.