### PR TITLE
Fixes inifinite typo

### DIFF
--- a/Example/SwiftEntryKit/Playground/Cells/DisplayDurationSelectionTableViewCell.swift
+++ b/Example/SwiftEntryKit/Playground/Cells/DisplayDurationSelectionTableViewCell.swift
@@ -14,7 +14,7 @@ class DisplayDurationSelectionTableViewCell: SelectionTableViewCell {
         super.configure(attributesWrapper: attributesWrapper)
         titleValue = "Display Duration"
         descriptionValue = "How long the entry is displayed"
-        insertSegments(by: ["2 Seconds", "4 Seconds", "Infinate"])
+        insertSegments(by: ["2 Seconds", "4 Seconds", "infinite"])
         selectSegment()
     }
     

--- a/Example/SwiftEntryKit/Presets/PresetsData/PresetsDataSource.swift
+++ b/Example/SwiftEntryKit/Presets/PresetsData/PresetsDataSource.swift
@@ -183,7 +183,7 @@ struct PresetsDataSource {
         attributes.popBehavior = .animated(animation: .translation)
         attributes.entryBackground = .color(color: .pinky)
         attributes.statusBar = .light
-        descriptionString = "Appears for an infinate duration"
+        descriptionString = "Appears for an infinite duration"
         descriptionThumb = ThumbDesc.topNote.rawValue
         description = .init(with: attributes, title: "Top Processing Note", description: descriptionString, thumb: descriptionThumb)
         notes.append(description)

--- a/Example/SwiftEntryKit/Presets/PresetsViewController.swift
+++ b/Example/SwiftEntryKit/Presets/PresetsViewController.swift
@@ -60,7 +60,7 @@ class PresetsViewController: UIViewController {
         SwiftEntryKit.display(entry: contentView, using: attributes)
     }
     
-    // Bumps an infinate processing note
+    // Bumps an infinite processing note
     private func showProcessingNote(attributes: EKAttributes) {
         let text = "Waiting for the goodies to arrive!"
         let style = EKProperty.LabelStyle(font: MainFont.light.with(size: 14), color: .white, alignment: .center)

--- a/Example/Tests/AttributesCreationTests.swift
+++ b/Example/Tests/AttributesCreationTests.swift
@@ -112,7 +112,7 @@ class AttributesCreation: QuickSpec {
                 attributes = EKAttributes()
             }
             
-            it("displays for infinate time") {
+            it("displays for infinite time") {
                 duration = .infinity
                 attributes.displayDuration = duration
                 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Display for 2 seconds:
 attributes.displayDuration = 2
 ```
 
-Display for an infinate duration
+Display for an infinite duration
 ```Swift
 attributes.displayDuration = .infinity
 ```

--- a/Source/Model/EntryAttributes/EKAttributes.swift
+++ b/Source/Model/EntryAttributes/EKAttributes.swift
@@ -31,7 +31,7 @@ public struct EKAttributes {
     public var displayPriority = DisplayPriority.normal
     
     /** Describes how long the entry is displayed before it is dismissed */
-    public var displayDuration: DisplayDuration = 2 // Use .infinity for infinate duration
+    public var displayDuration: DisplayDuration = 2 // Use .infinity for infinite duration
     
     /** The frame attributes of the entry */
     public var positionConstraints = PositionConstraints()


### PR DESCRIPTION
Small typo present in a few different locations.
Replaces `inifinate` with `infinite`.