### PR TITLE
Round corners of content view

### DIFF
--- a/Source/Infra/EKEntryView.swift
+++ b/Source/Infra/EKEntryView.swift
@@ -121,6 +121,12 @@ class EKEntryView: EKStyleView {
     // Apply round corners
     private func applyFrameStyle() {
         backgroundView.applyFrameStyle(roundCorners: attributes.roundCorners, border: attributes.border)
+        
+        // round corners of content view, to be sure, that buttons have same corner radius.
+        if case .all(let cornerRadius) = content.attributes.roundCorners {
+            content.view.layer.cornerRadius = cornerRadius
+            content.view.layer.masksToBounds = true
+        }
     }
     
     // Apply drop shadow


### PR DESCRIPTION
### Issue Link 🔗
When using EKAlertMessageView with two buttons, and all corners rounded, buttons are rectangle.

### Goals 🥅
*What have I tried to achieve / improve + use case example*

### Implementation Details ✏️
This commit is fixing specific situation: two buttons in alert view.

### Testing Details 🔍
*How did I test my implementation*

### Screenshot Links 📷
*Since this a visual project, focusing maily on UI and UX, please attach screenshots in case of UI related change*
![simulator screen shot - iphone 8 plus - 2018-08-30 at 20 19 10](https://user-images.githubusercontent.com/1624643/44868060-4c4b3500-ac92-11e8-8763-5f5aa2aa4bbc.png)
![simulator screen shot - iphone 8 plus - 2018-08-30 at 20 19 41](https://user-images.githubusercontent.com/1624643/44868068-55d49d00-ac92-11e8-84d5-ea784404e99a.png)