### PR TITLE
Bugfix - numberOfLines property #111: EKImageNoteMessageView multiple…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+## 0.7.2
+
+### Bug Fixes
+
+
+
 ## 0.7.1
 
 ### Feature - Add a way to make a specific text field first responder in `EKFormMessageView`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Any notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-
+(numberOfLines property #111)https://github.com/huri000/SwiftEntryKit/issues/111] - Allow multiple lines in image notes.
 
 ## 0.7.1
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.3.1)
   - Quick (1.3.2)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.7.1):
+  - SwiftEntryKit (0.7.2):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 16d79be92181bf97d846ea5d760cf8938400585a
+  SwiftEntryKit: 51f310c97a7453b9dc5b925d93bac01c9ff43353
 
 PODFILE CHECKSUM: bebf3cef20d24f5c1ea859b0e649573b6222aec0
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -17,7 +17,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.7.1"
+    "tag": "0.7.2"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.3.1)
   - Quick (1.3.2)
   - QuickLayout (2.0.2)
-  - SwiftEntryKit (0.7.1):
+  - SwiftEntryKit (0.7.2):
     - QuickLayout (= 2.0.2)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   QuickLayout: a730730b646b231fd4ef7cffaeb1e81fe0e1ca92
-  SwiftEntryKit: 16d79be92181bf97d846ea5d760cf8938400585a
+  SwiftEntryKit: 51f310c97a7453b9dc5b925d93bac01c9ff43353
 
 PODFILE CHECKSUM: bebf3cef20d24f5c1ea859b0e649573b6222aec0
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.7.1</string>
+  <string>0.7.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.7.1'
+pod 'SwiftEntryKit', '0.7.2'
 ```
 
 Then, run the following command:
@@ -159,7 +159,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.7.1
+github "huri000/SwiftEntryKit" == 0.7.2
 ```
 
 ## Usage

--- a/Source/MessageViews/Notes/EKAccessoryNoteMessageView.swift
+++ b/Source/MessageViews/Notes/EKAccessoryNoteMessageView.swift
@@ -19,6 +19,8 @@ public class EKAccessoryNoteMessageView: UIView {
         
         addSubview(contentView)
         contentView.layoutToSuperview(.centerX, .top, .bottom)
+        contentView.layoutToSuperview(.left, relation: .greaterThanOrEqual, offset: 16)
+        contentView.layoutToSuperview(.right, relation: .lessThanOrEqual, offset: -16)
         
         noteMessageView = EKNoteMessageView(with: content)
         noteMessageView.horizontalOffset = 8

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.7.1'
+  s.version = '0.7.2'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
… lines shoves the content aside.

### Issue Link 🔗
[numberOfLines property #111](https://github.com/huri000/SwiftEntryKit/issues/111).

### Goals 🥅
*What have I tried to achieve/improve + use case example*

### Implementation Details ✏️
Added relation constraints - bigger than / less than the screen width, to the contentView of the note to behave similarly to Stack View.
