### PR TITLE
Documentation for Objective-C compatibility #91.

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,8 +837,11 @@ Orientation Change Demonstration |
 ![orientation_change](https://github.com/huri000/assets/blob/master/swift-entrykit/orientation.gif)
 
 ### Swift and Objective-C Interoperability
-SwiftEntryKit's API uses syntax there is Swift exclusive, therefore, it doesn't support Objective-C projects by design.
-Yet, it is easy to integrate SwiftEntryKit into an Objective-C project using a simple *.swift* class that is a sort of adapter or mediator between your code and SwiftEntryKit's API. 
+SwiftEntryKit's API uses the Swift language exclusive syntax (enums, associated values, and more). 
+Therefore, `SwiftEntryKit` cannot be referenced directly from an Objective-C file (*.m*, *.h* or *.mm*).
+
+Yet, it is pretty easy to integrate SwiftEntryKit into an Objective-C project using a simple *.swift* class that is a sort of adapter between `SwiftEntryKit` and your Objective-C code.
+
 [This project](https://github.com/huri000/ObjcEntryKitExample) demonstrates that using Carthage and CocoaPods.  
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@
   * [Displaying a View Controller](#displaying-a-view-controller)
   * [Alternative Rollback Window](#alternative-rollback-window)
   * [Dismissing an Entry](#dismissing-an-entry)
-  * [Swiping And Rubber Banding](#swiping-and-rubber-banding)
+  * [Swiping and Rubber Banding](#swiping-and-rubber-banding)
   * [Dealing With Safe Area](#dealing-with-safe-area)
   * [Dealing With Orientation Change](#dealing-with-orientation-change)
+  * [Swift and Objective-C Interoperability](#swift-and-objective-c-interoperability)
 * [Known Issues](#known-issues)
 * [Author](#author)
 * [License](#license)
@@ -834,6 +835,11 @@ SwiftEntryKit.display(entry: customView, using: attributes)
 Orientation Change Demonstration |
 --- |
 ![orientation_change](https://github.com/huri000/assets/blob/master/swift-entrykit/orientation.gif)
+
+### Swift and Objective-C Interoperability
+SwiftEntryKit's API uses syntax there is Swift exclusive, therefore, it doesn't support Objective-C projects by design.
+Yet, it is easy to integrate SwiftEntryKit into an Objective-C project using a simple *.swift* class that is a sort of adapter or mediator between your code and SwiftEntryKit's API. 
+[This project](https://github.com/huri000/ObjcEntryKitExample) demonstrates that using Carthage and CocoaPods.  
 
 ## Known Issues
 


### PR DESCRIPTION
Added documentation explaining Objective-C support in SwiftEntryKit.

### Issue Link 🔗
Objective-C compatibility #91 

