### PR TITLE
Bug Fix: Issue #119 - Entry tap gesture doesn't cancel touches inside…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+## 0.8.2
+
+### Bug Fixes:
+[Issue #119](https://github.com/huri000/SwiftEntryKit/issues/119) - Entry tap gesture doesn't cancel touches inside the entry view. 
+
 ## 0.8.1
 
 Apply a necessary fix for Xcode 10 and older than 4.2 Swift version compatibility.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.3.1)
   - Quick (1.3.2)
   - QuickLayout (2.1.1)
-  - SwiftEntryKit (0.8.1):
+  - SwiftEntryKit (0.8.2):
     - QuickLayout (= 2.1.1)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   QuickLayout: 9af2b7fd89a6552828f51a5aba28d1bcdb8b340c
-  SwiftEntryKit: 00a33dff5ddcefd2bd5eac2784778cd4362dd4b6
+  SwiftEntryKit: 6b3ed18297336ca3aa7d33477d3758cdbf24a6db
 
 PODFILE CHECKSUM: bebf3cef20d24f5c1ea859b0e649573b6222aec0
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -18,7 +18,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.8.1"
+    "tag": "0.8.2"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.3.1)
   - Quick (1.3.2)
   - QuickLayout (2.1.1)
-  - SwiftEntryKit (0.8.1):
+  - SwiftEntryKit (0.8.2):
     - QuickLayout (= 2.1.1)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   QuickLayout: 9af2b7fd89a6552828f51a5aba28d1bcdb8b340c
-  SwiftEntryKit: 00a33dff5ddcefd2bd5eac2784778cd4362dd4b6
+  SwiftEntryKit: 6b3ed18297336ca3aa7d33477d3758cdbf24a6db
 
 PODFILE CHECKSUM: bebf3cef20d24f5c1ea859b0e649573b6222aec0
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.8.1</string>
+  <string>0.8.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ The Playground Screen | Top Toast Sample
 
 ## Installation
 
-SwiftEntryKit is compatible with Xcode 10 as of release *0.8.1*. Developers who are still using Xcode 9.x.y can install release 0.7.2, or lower versions.
+SwiftEntryKit is compatible with Xcode 10 as of release *0.8.1*. 
+Developers who use Xcode 9.x.y can install release 0.7.2, or any lower version.
 
 ### CocoaPods
 
@@ -849,9 +850,8 @@ Yet, it is pretty easy to integrate SwiftEntryKit into an Objective-C project us
 
 ## Known Issues
 
-As of release *0.8.1*, SwiftEntryKit is compatible with Xcode 10
+As of release *0.8.1*, SwiftEntryKit is compatible with Xcode 10. 
 Developers who are still using Xcode 9.x.y can install release *0.7.2*.
-Other possible workarounds: [Swift 4.2 Support](https://github.com/huri000/SwiftEntryKit/issues/108#issuecomment-425374479)
 
 **Unable to find specification for SwiftEntryKit (=X.Y.Z)** - In case you get this error please review [this thread](https://github.com/huri000/SwiftEntryKit/issues/4).
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.8.1'
+pod 'SwiftEntryKit', '0.8.2'
 ```
 
 Then, run the following command:
@@ -163,7 +163,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.8.1
+github "huri000/SwiftEntryKit" == 0.8.2
 ```
 
 ## Usage

--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -296,6 +296,7 @@ class EKContentView: UIView {
         }
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapGestureRecognized))
         tapGestureRecognizer.numberOfTapsRequired = 1
+        tapGestureRecognizer.cancelsTouchesInView = false
         addGestureRecognizer(tapGestureRecognizer)
     }
     

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.8.1'
+  s.version = '0.8.2'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
… the entry view.

### Issue Link 🔗
[Issue #119](https://github.com/huri000/SwiftEntryKit/issues/119) - Entry tap gesture doesn't cancel touches inside the entry view. 

### Goals 🥅
Fix the absorbTouches - Let the entry handle the touches.
