### PR TITLE
Hot-fix an ignored background fade animation:

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.3.1)
   - Quick (1.3.2)
   - QuickLayout (2.1.1)
-  - SwiftEntryKit (0.8.2):
+  - SwiftEntryKit (0.8.3):
     - QuickLayout (= 2.1.1)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   QuickLayout: 9af2b7fd89a6552828f51a5aba28d1bcdb8b340c
-  SwiftEntryKit: 6b3ed18297336ca3aa7d33477d3758cdbf24a6db
+  SwiftEntryKit: d8bff6071dfd4d0ca84f403828747b80b041df0c
 
 PODFILE CHECKSUM: bebf3cef20d24f5c1ea859b0e649573b6222aec0
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -18,7 +18,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "0.8.2"
+    "tag": "0.8.3"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (7.3.1)
   - Quick (1.3.2)
   - QuickLayout (2.1.1)
-  - SwiftEntryKit (0.8.2):
+  - SwiftEntryKit (0.8.3):
     - QuickLayout (= 2.1.1)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
   Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
   QuickLayout: 9af2b7fd89a6552828f51a5aba28d1bcdb8b340c
-  SwiftEntryKit: 6b3ed18297336ca3aa7d33477d3758cdbf24a6db
+  SwiftEntryKit: d8bff6071dfd4d0ca84f403828747b80b041df0c
 
 PODFILE CHECKSUM: bebf3cef20d24f5c1ea859b0e649573b6222aec0
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.8.2</string>
+  <string>0.8.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '0.8.2'
+pod 'SwiftEntryKit', '0.8.3'
 ```
 
 Then, run the following command:
@@ -164,7 +164,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 0.8.2
+github "huri000/SwiftEntryKit" == 0.8.3
 ```
 
 ## Usage

--- a/Source/Infra/EKRootViewController.swift
+++ b/Source/Infra/EKRootViewController.swift
@@ -38,8 +38,12 @@ class EKRootViewController: UIViewController {
         }
     }
     
+    /*
+     Count the total amount of currently displaying entries,
+     meaning, total subviews less one - the backgorund of the entry
+     */
     fileprivate var displayingEntryCount: Int {
-        return view.subviews.count
+        return view.subviews.count - 1
     }
     
     fileprivate var isDisplaying: Bool {
@@ -194,10 +198,6 @@ extension EKRootViewController: EntryContentViewDelegate {
         delegate.displayPendingEntryIfNeeded()
     }
     
-    func changeToActive(withAttributes attributes: EKAttributes) {
-        changeBackground(to: attributes.screenBackground, duration: attributes.entranceAnimation.totalDuration)
-    }
-    
     func changeToInactive(withAttributes attributes: EKAttributes, pushOut: Bool) {
         guard displayingEntryCount <= 1 else {
             return
@@ -220,6 +220,10 @@ extension EKRootViewController: EntryContentViewDelegate {
         if lastBackroundStyle != attributes.screenBackground {
             clear()
         }
+    }
+    
+    func changeToActive(withAttributes attributes: EKAttributes) {
+        changeBackground(to: attributes.screenBackground, duration: attributes.entranceAnimation.totalDuration)
     }
     
     private func changeBackground(to style: EKAttributes.BackgroundStyle, duration: TimeInterval) {

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '0.8.2'
+  s.version = '0.8.3'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
### Issue Link 🔗
Background dimmed view is NOT animating #132

### Goals 🥅
Fixed the bug that disrupts entry background animation.
 
### Implementation Details ✏️
`displayingEntryCount`, a computed property within `EKRootViewController` returns the wrong number of displayed entries, not taking into account the surplus background view as subview.
