### PR TITLE
Additional EKProperty init method to support [ButtonContent] parameter

### DIFF
--- a/Source/Model/EKProperty.swift
+++ b/Source/Model/EKProperty.swift
@@ -196,6 +196,10 @@ public struct EKProperty {
         public var buttonHeight: CGFloat
         
         public init(with buttonContents: ButtonContent..., separatorColor: UIColor, horizontalDistributionThreshold: Int = 2, buttonHeight: CGFloat = 50, expandAnimatedly: Bool) {
+            self.init(with: buttonContents, separatorColor: separatorColor, horizontalDistributionThreshold: horizontalDistributionThreshold, buttonHeight: buttonHeight, expandAnimatedly: expandAnimatedly)
+        }
+        
+        public init(with buttonContents: [ButtonContent], separatorColor: UIColor, horizontalDistributionThreshold: Int = 2, buttonHeight: CGFloat = 50, expandAnimatedly: Bool) {
             guard horizontalDistributionThreshold > 0 else {
                 fatalError("horizontalDistributionThreshold Must have a positive value!")
             }


### PR DESCRIPTION
*Issue Link* 🔗
https://github.com/huri000/SwiftEntryKit/issues/187

*Details* ✏️
ButtonBarContent can now be initialised using an array of ButtonContent as well as the original variadic. This is useful when creating a controller class and passing in multiple buttons when creating the alert.