### PR TITLE
Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@ DerivedData
 
 Carthage/Build
 
-
-
-
+# SwiftPM
+.swiftpm/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "SwiftEntryKit", targets: ["SwiftEntryKit"])
   ],
   dependencies: [
-    .package(url: "https://github.com/huri000/QuickLayout", .branch("master"))
+    .package(url: "https://github.com/huri000/QuickLayout", .exact("3.0.2"))
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "SwiftEntryKit", targets: ["SwiftEntryKit"])
   ],
   dependencies: [
-    .package(url: "https://github.com/maxxfrazer/QuickLayout", .branch("master"))
+    .package(url: "https://github.com/huri000/QuickLayout", .branch("master"))
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "SwiftEntryKit", targets: ["SwiftEntryKit"])
   ],
   dependencies: [
-    .package(url: "https://github.com/huri000/QuickLayout", .exact("3.0.2"))
+    .package(url: "https://github.com/huri000/QuickLayout", .exact("3.0.1"))
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "SwiftEntryKit",
+  platforms: [
+    .iOS(.v9)
+  ],
+  products: [
+    .library(name: "SwiftEntryKit", targets: ["SwiftEntryKit"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/maxxfrazer/QuickLayout", .branch("master"))
+  ],
+  targets: [
+    .target(
+      name: "SwiftEntryKit",
+      dependencies: ["QuickLayout"],
+      path: "Source"
+    )
+  ],
+  swiftLanguageVersions: [
+    .v5
+  ]
+)

--- a/Source/Extensions/UIRectCorner+Short.swift
+++ b/Source/Extensions/UIRectCorner+Short.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension UIRectCorner {
     static let top: UIRectCorner = [.topLeft, .topRight]

--- a/Source/Infra/EKStyleView.swift
+++ b/Source/Infra/EKStyleView.swift
@@ -5,6 +5,8 @@
 //  Created by Daniel Huri on 4/28/18.
 //
 
+import UIKit
+
 class EKStyleView: UIView {
     
     private lazy var borderLayer: CAShapeLayer = {

--- a/Source/MessageViews/MessagesUtils/EKRatingSymbolView.swift
+++ b/Source/MessageViews/MessagesUtils/EKRatingSymbolView.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 huri000@gmail.com. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public class EKRatingSymbolView: UIView {
     

--- a/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
+++ b/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 huri000@gmail.com. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 public class EKRatingSymbolsContainerView: UIView {
     

--- a/Source/MessageViews/MessagesUtils/EntryAppearanceDescriptor.swift
+++ b/Source/MessageViews/MessagesUtils/EntryAppearanceDescriptor.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 CocoaPods. All rights reserved.
 //
 
-import Foundation
+import CoreGraphics
 
 /**
  An anti-pattern for SwiftEntryKit views to know more about their appearence,

--- a/Source/MessageViews/Notes/EKImageNoteMessageView.swift
+++ b/Source/MessageViews/Notes/EKImageNoteMessageView.swift
@@ -5,7 +5,7 @@
 //  Created by Daniel Huri on 5/4/18.
 //
 
-import Foundation
+import UIKit
 
 public class EKImageNoteMessageView: EKAccessoryNoteMessageView {
     

--- a/Source/Model/EntryAttributes/EKAttributes+FrameStyle.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+FrameStyle.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import CoreGraphics
+import UIKit
 
 public extension EKAttributes {
     

--- a/Source/Model/EntryAttributes/EKAttributes+HapticFeedback.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+HapticFeedback.swift
@@ -5,7 +5,7 @@
 //  Created by Daniel Huri on 5/1/18.
 //
 
-import Foundation
+import UIKit
 
 public extension EKAttributes {
     

--- a/Source/Model/EntryAttributes/EKAttributes+Scroll.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+Scroll.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 public extension EKAttributes {
     

--- a/Source/SwiftEntryKit.swift
+++ b/Source/SwiftEntryKit.swift
@@ -5,7 +5,7 @@
 //  Created by Daniel Huri on 4/29/18.
 //
 
-import Foundation
+import UIKit
 
 /**
  A stateless, threadsafe (unless described otherwise) entry point that contains the display and the dismissal logic of entries.

--- a/Source/Utils/HapticFeedbackGenerator.swift
+++ b/Source/Utils/HapticFeedbackGenerator.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2018 huri000@gmail.com. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 struct HapticFeedbackGenerator {
     @available(iOS 10.0, *)


### PR DESCRIPTION
added support for Swift Package Manager. Added import statements to any troublesome files in Sources/*

### Goals 🥅
- Add Swift Package Manager Support
This PR needs to be merged first:
https://github.com/huri000/QuickLayout/pull/32

### Implementation Details ✏️
- Added Package.swift
- Added import of relevant libraries in some source files
  - It seems Xcode 11 is more strict on these things

### Testing Details 🔍
- Used the Example project to see if anything had broken, haven't committed that yet as it'll make the PR messy (pod updates are included)

### Screenshot Links 📷
No visible changes