### PR TITLE
fix(#231): fix screen interaction for iPad on iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 Any notable changes to this project will be documented in this file.
 
+## 1.1.4
+Fixes: #231 (iPad + iOS13) entries background is not interactable. 
+
 ## 1.1.3
 Fix `SPM` release
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (8.0.1)
   - Quick (2.0.0)
   - QuickLayout (3.0.0)
-  - SwiftEntryKit (1.1.3):
+  - SwiftEntryKit (1.1.4):
     - QuickLayout (= 3.0.0)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
   Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
   QuickLayout: 07b45a72b10083fee3f095990cfed1c1e7b27f0a
-  SwiftEntryKit: be00509cf6e1e88b57bb96cf2114b09cf20ee84a
+  SwiftEntryKit: fa997eb1c45afb5cf27ab0145e680759dd7152ca
 
 PODFILE CHECKSUM: cfefcd17a3b135cb5b254a0b85e280fd33f2919e
 

--- a/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftEntryKit.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "SwiftEntryKit",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "summary": "A simple banner and pop-up displayer for iOS. Written in Swift.",
   "platforms": {
     "ios": "9.0"
@@ -18,7 +18,7 @@
   },
   "source": {
     "git": "https://github.com/huri000/SwiftEntryKit.git",
-    "tag": "1.1.3"
+    "tag": "1.1.4"
   },
   "source_files": "Source/**/*",
   "frameworks": "UIKit",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,7 +2,7 @@ PODS:
   - Nimble (8.0.1)
   - Quick (2.0.0)
   - QuickLayout (3.0.0)
-  - SwiftEntryKit (1.1.3):
+  - SwiftEntryKit (1.1.4):
     - QuickLayout (= 3.0.0)
 
 DEPENDENCIES:
@@ -24,7 +24,7 @@ SPEC CHECKSUMS:
   Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
   Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
   QuickLayout: 07b45a72b10083fee3f095990cfed1c1e7b27f0a
-  SwiftEntryKit: be00509cf6e1e88b57bb96cf2114b09cf20ee84a
+  SwiftEntryKit: fa997eb1c45afb5cf27ab0145e680759dd7152ca
 
 PODFILE CHECKSUM: cfefcd17a3b135cb5b254a0b85e280fd33f2919e
 

--- a/Example/Pods/Target Support Files/SwiftEntryKit/SwiftEntryKit-Info.plist
+++ b/Example/Pods/Target Support Files/SwiftEntryKit/SwiftEntryKit-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.3</string>
+  <string>1.1.4</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ![](https://travis-ci.com/huri000/SwiftEntryKit.svg?branch=master)
 
 ## What's New?
-### 🌑 `1.1.3` - let there be dark
+### 🌑 `1.1.4` - let there be dark
 `SwiftEntryKit` is now dark mode ready, and user interface styles are supported pre iOS 13 / Xcode 11!
 
 To know more about it, visit [Change Log](https://github.com/huri000/SwiftEntryKit/blob/master/CHANGELOG.md#110), and install the [example project](#example-project-installation).
@@ -156,7 +156,7 @@ source 'https://github.com/cocoapods/specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
-pod 'SwiftEntryKit', '1.1.3'
+pod 'SwiftEntryKit', '1.1.4'
 ```
 
 Then, run the following command:
@@ -179,7 +179,7 @@ $ brew install carthage
 To integrate SwiftEntryKit into your Xcode project using Carthage, specify the following in your `Cartfile`:
 
 ```ogdl
-github "huri000/SwiftEntryKit" == 1.1.3
+github "huri000/SwiftEntryKit" == 1.1.4
 ```
 
 ### Accio
@@ -196,7 +196,7 @@ $ brew install accio
 To integrate SwiftEntryKit into your Xcode project using Accio, specify the following in your `Package.swift` manifest:
 
 ```swift
-.package(url: "https://github.com/huri000/SwiftEntryKit", .exact("1.1.3"))
+.package(url: "https://github.com/huri000/SwiftEntryKit", .exact("1.1.4"))
 ```
 
 After specifying `"SwiftEntryKit"` as a dependency of the target in which you want to use it, run `accio install`.

--- a/Source/Infra/EKWindow.swift
+++ b/Source/Infra/EKWindow.swift
@@ -26,9 +26,15 @@ class EKWindow: UIWindow {
         if isAbleToReceiveTouches {
             return super.hitTest(point, with: event)
         }
-        if let view = super.hitTest(point, with: event), view != self {
+        
+        guard let rootVC = EKWindowProvider.shared.rootVC else {
+            return nil
+        }
+        
+        if let view = rootVC.view.hitTest(point, with: event) {
             return view
         }
+        
         return nil
     }
 }

--- a/SwiftEntryKit.podspec
+++ b/SwiftEntryKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name = 'SwiftEntryKit'
-  s.version = '1.1.3'
+  s.version = '1.1.4'
   s.summary = 'A simple banner and pop-up displayer for iOS. Written in Swift.'
   s.platform = :ios
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
### Issue Link 🔗
#231

### Goals 🥅
To fix screen interaction issues when for `forward`. Happens on iPad devices, iOS 13.

### Implementation Details ✏️
iPad + iOS 13 `UIWindow` has a different UIView hierarchy with 2 additional views between the content and the parent window. Instead of trying to `hitTest` on the `UIWindow` - go directly to the `EKRootViewController` which (anyways) contains the relevant view hierarchy.
