### PR TITLE
`EKWindow` initialiser filters scenes using first `foregroundActive`.

### DIFF
--- a/Source/Infra/EKWindow.swift
+++ b/Source/Infra/EKWindow.swift
@@ -15,7 +15,7 @@ class EKWindow: UIWindow {
     init(with rootVC: UIViewController) {
         if #available(iOS 13.0, *) {
             // TODO: Patched to support SwiftUI out of the box but should require attendance
-            if let scene = UIApplication.shared.connectedScenes.first(where: { $0 is UIWindowScene } ) as? UIWindowScene {
+            if let scene = UIApplication.shared.connectedScenes.filter({$0.activationState == .foregroundActive}).first as? UIWindowScene {
                 super.init(windowScene: scene)
             } else {
                 super.init(frame: UIScreen.main.bounds)


### PR DESCRIPTION
Resolves #251

Could do with more work, but for now this resolves issue we're experiencing. 