### PR TITLE
Added size option for EKRatingSymbolsContainerView

### DIFF
--- a/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
+++ b/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
@@ -27,7 +27,7 @@ final public class EKRatingSymbolsContainerView: UIView {
                                               selection: internalSelection)
             itemView.tag = index
             addSubview(itemView)
-            itemView.set(.width, .height, of: 50)
+            itemView.set(.width, .height, of: 32)
             symbolsArray.append(itemView)
         }
         symbolsArray.layoutToSuperview(axis: .vertically, priority: .must)

--- a/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
+++ b/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
@@ -27,7 +27,8 @@ final public class EKRatingSymbolsContainerView: UIView {
                                               selection: internalSelection)
             itemView.tag = index
             addSubview(itemView)
-            itemView.set(.width, .height, of: 32)
+            itemView.set(.height, of: item.size.height)
+            itemView.set(.width, of: item.size.width)
             symbolsArray.append(itemView)
         }
         symbolsArray.layoutToSuperview(axis: .vertically, priority: .must)

--- a/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
+++ b/Source/MessageViews/MessagesUtils/EKRatingSymbolsContainerView.swift
@@ -34,7 +34,7 @@ final public class EKRatingSymbolsContainerView: UIView {
         symbolsArray.layoutToSuperview(axis: .vertically, priority: .must)
         symbolsArray.spread(.horizontally, stretchEdgesToSuperview: true)
         
-        select()
+        select(index: message.selectedIndex)
     }
     
     private func select(index: Int? = nil) {

--- a/Source/Model/EKProperty.swift
+++ b/Source/Model/EKProperty.swift
@@ -379,15 +379,18 @@ public struct EKProperty {
         public var description: EKProperty.LabelContent
         public var unselectedImage: EKProperty.ImageContent
         public var selectedImage: EKProperty.ImageContent
-    
+        public var size: CGSize
+        
         public init(title: EKProperty.LabelContent,
                     description: EKProperty.LabelContent,
                     unselectedImage: EKProperty.ImageContent,
-                    selectedImage: EKProperty.ImageContent) {
+                    selectedImage: EKProperty.ImageContent,
+                    size: CGSize = CGSize(width: 50, height: 50)) {
             self.title = title
             self.description = description
             self.unselectedImage = unselectedImage
             self.selectedImage = selectedImage
+            self.size = size
         }
     }
 }


### PR DESCRIPTION
### Goals 🥅
Be able to set a custom size for the Rating Symbol Container View. 

For example: if you want to show more than 5 stars in a row, now you can set the Rating Symbol Container View to 30 px (width and height).

### Implementation Details ✏️
Just adding a size (CGSize) var in EKRatingItemContent and then updating the size in EKRatingSymbolsContainerView.
