### PR TITLE
UITextField Delegate Functionality

### DIFF
--- a/Source/MessageViews/MessagesUtils/EKTextField.swift
+++ b/Source/MessageViews/MessagesUtils/EKTextField.swift
@@ -56,6 +56,7 @@ final public class EKTextField: UIView {
     private func setupTextField() {
         addSubview(textField)
         textField.textFieldContent = content
+        textField.delegate = content.delegate
         textField.set(.height, of: EKTextField.totalHeight)
         textField.layout(.leading, to: .trailing, of: imageView)
         textField.layoutToSuperview(.top, .trailing)

--- a/Source/Model/EKProperty.swift
+++ b/Source/Model/EKProperty.swift
@@ -268,6 +268,7 @@ public struct EKProperty {
             var text = ""
         }
         
+        public var delegate: UITextFieldDelegate?
         public var keyboardType: UIKeyboardType
         public var isSecure: Bool
         public var leadingImage: UIImage!
@@ -287,7 +288,8 @@ public struct EKProperty {
             }
         }
         
-        public init(keyboardType: UIKeyboardType = .default,
+        public init(delegate: UITextFieldDelegate,
+                    keyboardType: UIKeyboardType = .default,
                     placeholder: LabelContent,
                     tintColor: EKColor? = nil,
                     displayMode: EKAttributes.DisplayMode = .inferred,
@@ -296,6 +298,8 @@ public struct EKProperty {
                     leadingImage: UIImage? = nil,
                     bottomBorderColor: EKColor = .clear,
                     accessibilityIdentifier: String? = nil) {
+            self.delegate = delegate
+
             self.keyboardType = keyboardType
             self.placeholder = placeholder
             self.textStyle = textStyle

--- a/Source/Model/EKProperty.swift
+++ b/Source/Model/EKProperty.swift
@@ -288,7 +288,7 @@ public struct EKProperty {
             }
         }
         
-        public init(delegate: UITextFieldDelegate,
+        public init(delegate: UITextFieldDelegate? = nil,
                     keyboardType: UIKeyboardType = .default,
                     placeholder: LabelContent,
                     tintColor: EKColor? = nil,

--- a/Source/Model/EKProperty.swift
+++ b/Source/Model/EKProperty.swift
@@ -268,7 +268,7 @@ public struct EKProperty {
             var text = ""
         }
         
-        public var delegate: UITextFieldDelegate?
+        public weak var delegate: UITextFieldDelegate?
         public var keyboardType: UIKeyboardType
         public var isSecure: Bool
         public var leadingImage: UIImage!

--- a/Source/Model/EKProperty.swift
+++ b/Source/Model/EKProperty.swift
@@ -299,7 +299,6 @@ public struct EKProperty {
                     bottomBorderColor: EKColor = .clear,
                     accessibilityIdentifier: String? = nil) {
             self.delegate = delegate
-
             self.keyboardType = keyboardType
             self.placeholder = placeholder
             self.textStyle = textStyle


### PR DESCRIPTION
### Issue Link 🔗
*A link to the issue & short explanation*
I was unable to set the text field delegate, so I added a textfieldDelegate property to your textField content.

### Goals 🥅
*What have I tried to achieve / improve + use case example*
I have a controller that is build around swiftEntryKit. this small tweak allows modularity and consistency in our project. We can now run our textField delegate methods.
### Implementation Details ✏️
*How did I implement*

I added a UITextFieldDelegateProperty to your EKProperty.TextFieldContent and then set the delegate in the EKTextField view class. All I had to do was pass in the view as a parameter in my method to create an alert.

### Testing Details 🔍
*How did I test my implementation*

### Screenshot Links 📷
*Since this a visual project, focusing maily on UI and UX, please attach screenshots in case of UI related change*

no UI changes