### PR TITLE
Fixed crash with pan gesture due to division by 0

### DIFF
--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -669,6 +669,7 @@ extension EKContentView {
     }
     
     private func calculateLogarithmicOffset(forOffset offset: CGFloat, currentTranslation: CGFloat) {
+        guard verticalLimit != 0 else { return }
         if attributes.position.isTop {
             inConstraint.constant = verticalLimit * (1 + log10(offset / verticalLimit))
         } else {


### PR DESCRIPTION
### Issue Link 🔗
#277 - If you tap on the view it will crash due to a division by zero

### Goals 🥅
Prent division by zero

### Implementation Details ✏️
Added a validation to prevent this. Discarding the cases where `verticalLimit` is 0 and it did not cause any issue, but you guys can check since you have a better knowledge of the codebase 
