### PR TITLE
fix(Key Window): #324 - make previous window key again after dismissal

### DIFF
--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -12,7 +12,7 @@ import QuickLayout
 protocol EntryContentViewDelegate: class {
     func changeToActive(withAttributes attributes: EKAttributes)
     func changeToInactive(withAttributes attributes: EKAttributes, pushOut: Bool)
-    func didFinishDisplaying(entry: EKEntryView, keepWindowActive: Bool)
+    func didFinishDisplaying(entry: EKEntryView, keepWindowActive: Bool, dismissCompletionHandler: SwiftEntryKit.DismissCompletionHandler?)
 }
 
 class EKContentView: UIView {
@@ -473,16 +473,16 @@ class EKContentView: UIView {
         }
         
         // Execute didDisappear action if needed
-        contentView.content.attributes.lifecycleEvents.didDisappear?()
-        
-        // Execute dismiss handler if needed
-        dismissHandler?()
-        
+        let didDisappear = contentView.content.attributes.lifecycleEvents.didDisappear
+
         // Remove the view from its superview and in a case of a view controller, from its parent controller.
         super.removeFromSuperview()
         contentView.content.viewController?.removeFromParent()
         
-        entryDelegate.didFinishDisplaying(entry: contentView, keepWindowActive: keepWindow)
+        entryDelegate.didFinishDisplaying(entry: contentView, keepWindowActive: keepWindow, dismissCompletionHandler: dismissHandler)
+        
+        // Lastly, perform the Dismiss Completion Handler as the entry is no longer displayed
+        didDisappear?()
     }
     
     deinit {

--- a/Source/Infra/EKRootViewController.swift
+++ b/Source/Infra/EKRootViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol EntryPresenterDelegate: class {
     var isResponsiveToTouches: Bool { set get }
-    func displayPendingEntryIfNeeded()
+    func displayPendingEntryOrRollbackWindow(dismissCompletionHandler: SwiftEntryKit.DismissCompletionHandler?)
 }
 
 class EKRootViewController: UIViewController {
@@ -214,7 +214,7 @@ extension EKRootViewController {
 
 extension EKRootViewController: EntryContentViewDelegate {
     
-    func didFinishDisplaying(entry: EKEntryView, keepWindowActive: Bool) {
+    func didFinishDisplaying(entry: EKEntryView, keepWindowActive: Bool, dismissCompletionHandler: SwiftEntryKit.DismissCompletionHandler?) {
         guard !isDisplaying else {
             return
         }
@@ -223,7 +223,7 @@ extension EKRootViewController: EntryContentViewDelegate {
             return
         }
         
-        delegate.displayPendingEntryIfNeeded()
+        delegate.displayPendingEntryOrRollbackWindow(dismissCompletionHandler: dismissCompletionHandler)
     }
     
     func changeToInactive(withAttributes attributes: EKAttributes, pushOut: Bool) {

--- a/Source/Infra/EKWindowProvider.swift
+++ b/Source/Infra/EKWindowProvider.swift
@@ -169,11 +169,21 @@ final class EKWindowProvider: EntryPresenterDelegate {
     }
     
     /** Display a pending entry if there is any inside the queue */
-    func displayPendingEntryIfNeeded() {
+    func displayPendingEntryOrRollbackWindow(dismissCompletionHandler: SwiftEntryKit.DismissCompletionHandler?) {
         if let next = entryQueue.dequeue() {
+            
+            // Execute dismiss handler if needed before dequeuing (potentially) another entry
+            dismissCompletionHandler?()
+            
+            // Show the next entry in queue
             show(entryView: next.view, presentInsideKeyWindow: next.presentInsideKeyWindow, rollbackWindow: next.rollbackWindow)
         } else {
+            
+            // Display the rollback window
             displayRollbackWindow()
+            
+            // As a last step, invoke the dismissal method
+            dismissCompletionHandler?()
         }
     }
     


### PR DESCRIPTION
### Issue Link 🔗

#324

### Goals 🥅

Implement a fix for the issue above

### Implementation Details ✏️

By relocating the dismiss handlers' invocation to a later point in time, the host app can now identify the main / rollback window as key.
