### PR TITLE
Added support for relative horizontal offset

### DIFF
--- a/Example/SwiftEntryKit/Playground/PlaygroundViewController.swift
+++ b/Example/SwiftEntryKit/Playground/PlaygroundViewController.swift
@@ -173,6 +173,9 @@ extension PlaygroundViewController: UITableViewDelegate, UITableViewDataSource {
         case (4, 2):
             let cell = cell as! AnimationSelectionTableViewCell
             cell.configure(attributesWrapper: attributesWrapper, action: .pop)
+        case (4, 3):
+            let cell = cell as! AnimationSelectionTableViewCell
+            cell.configure(attributesWrapper: attributesWrapper, action: .exit)
         default:
             fatalError()
         }

--- a/Example/SwiftEntryKit/Presets/PresetsData/PresetsDataSource.swift
+++ b/Example/SwiftEntryKit/Presets/PresetsData/PresetsDataSource.swift
@@ -1157,6 +1157,84 @@ struct PresetsDataSource {
             thumb: descriptionThumb
         )
         presets.append(description)
+        
+        // Preset IV
+        attributes = .bottomFloat
+        attributes.displayMode = displayMode
+        attributes.hapticFeedbackType = .success
+        attributes.displayDuration = 3
+        attributes.screenBackground = .clear
+        attributes.entryBackground = .clear
+        attributes.screenInteraction = .forward
+        attributes.entryInteraction = .absorbTouches
+        attributes.entranceAnimation = .init(
+            translate: .init(
+                duration: 0.5,
+                spring: .init(damping: 0.9, initialVelocity: 0)
+            ),
+            scale: .init(
+                from: 0.8,
+                to: 1,
+                duration: 0.5,
+                spring: .init(damping: 0.8, initialVelocity: 0)
+            ),
+            fade: .init(
+                from: 0.7,
+                to: 1,
+                duration: 0.3
+            )
+        )
+        attributes.exitAnimation = .init(
+            translate: .init(duration: 0.5),
+            scale: .init(
+                from: 1,
+                to: 0.8,
+                duration: 0.5
+            ),
+            fade: .init(
+                from: 1,
+                to: 0,
+                duration: 0.5
+            )
+        )
+        attributes.popBehavior = .animated(
+            animation: .init(
+                translate: .init(
+                    duration: 0.3
+                ),
+                scale: .init(
+                    from: 1,
+                    to: 0.8,
+                    duration: 0.3
+                )
+            )
+        )
+        attributes.shadow = .active(
+            with: .init(
+                color: .black,
+                opacity: 0.3,
+                radius: 6
+            )
+        )
+        attributes.positionConstraints.verticalOffset = 10
+        attributes.positionConstraints.size = .init(
+            width: .relative(value: 30),
+            height: .intrinsic
+        )
+        attributes.positionConstraints.maxSize = .init(
+            width: .constant(value: UIScreen.main.minEdge),
+            height: .intrinsic
+        )
+        attributes.statusBar = .dark
+        descriptionString = "Customized UIViewController that is using an injected view with relative horizontal offset"
+        descriptionThumb = ThumbDesc.bottomFloat.rawValue
+        description = .init(
+            with: attributes,
+            title: "Horizontal offset View Controller",
+            description: descriptionString,
+            thumb: descriptionThumb
+        )
+        presets.append(description)
         dataSource.append(("Custom", presets))
     }
 }

--- a/Example/SwiftEntryKit/Presets/PresetsViewController.swift
+++ b/Example/SwiftEntryKit/Presets/PresetsViewController.swift
@@ -1043,6 +1043,8 @@ extension PresetsViewController {
             showCustomNibView(attributes: attributes)
         case 2:
             showCustomViewController(attributes: attributes)
+        case 3:
+            showCustomViewController(attributes: attributes)
         default:
             break
         }

--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -222,6 +222,8 @@ class EKContentView: UIView {
         switch attributes.positionConstraints.size.width {
         case .offset(value: let offset):
             layoutToSuperview(axis: .horizontally, offset: offset, priority: .must)
+        case .relative(value: let offset):
+            layout(to: .centerX, of: superview!, relation: .equal, offset: offset, priority: .must)
         case .ratio(value: let ratio):
             layoutToSuperview(.width, ratio: ratio, priority: .must)
         case .constant(value: let constant):
@@ -234,6 +236,8 @@ class EKContentView: UIView {
         switch attributes.positionConstraints.size.height {
         case .offset(value: let offset):
             layoutToSuperview(.height, offset: -offset * 2, priority: .must)
+        case .relative(value: _):
+            break
         case .ratio(value: let ratio):
             layoutToSuperview(.height, ratio: ratio, priority: .must)
         case .constant(value: let constant):
@@ -250,6 +254,8 @@ class EKContentView: UIView {
         case .offset(value: let offset):
             layout(to: .left, of: superview!, relation: .greaterThanOrEqual, offset: offset)
             layout(to: .right, of: superview!, relation: .lessThanOrEqual, offset: -offset)
+        case .relative(value: _):
+            break
         case .ratio(value: let ratio):
             layoutToSuperview(.centerX)
             layout(to: .width, of: superview!, relation: .lessThanOrEqual, ratio: ratio)
@@ -264,6 +270,8 @@ class EKContentView: UIView {
         switch attributes.positionConstraints.maxSize.height {
         case .offset(value: let offset):
             layout(to: .height, of: superview!, relation: .lessThanOrEqual, offset: -offset * 2)
+        case .relative(value: _):
+            break
         case .ratio(value: let ratio):
             layout(to: .height, of: superview!, relation: .lessThanOrEqual, ratio: ratio)
         case .constant(value: let constant):
@@ -276,7 +284,7 @@ class EKContentView: UIView {
     
     // Setup layout constraints according to EKAttributes.PositionConstraints
     private func setupLayoutConstraints() {
-        layoutToSuperview(.centerX)
+        //layoutToSuperview(.centerX)
         setupSize()
         setupMaxSize()
     }

--- a/Source/Model/EntryAttributes/EKAttributes+PositionConstraints.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+PositionConstraints.swift
@@ -47,6 +47,8 @@ public extension EKAttributes {
             /** Unspecified edge length */
             case intrinsic
             
+            case relative(value: CGFloat)
+            
             /** Edge totally filled */
             public static var fill: Edge {
                 return .offset(value: 0)


### PR DESCRIPTION
### Issue Link 🔗
https://github.com/huri000/SwiftEntryKit/issues/339
https://github.com/huri000/SwiftEntryKit/issues/218

### Goals 🥅

Being able to offset the content view horizontally

### Implementation Details ✏️
I added a new case to the Edge enumeration named "relative" that works as a relative offset to the content view

### Testing Details 🔍
There is a new demo case in the custom section with this relative offsetting

