### PR TITLE
Fix for rootVC issue

### DIFF
--- a/Source/Infra/EKWindow.swift
+++ b/Source/Infra/EKWindow.swift
@@ -15,7 +15,7 @@ class EKWindow: UIWindow {
     init(with rootVC: UIViewController) {
         if #available(iOS 13.0, *) {
             // TODO: Patched to support SwiftUI out of the box but should require attendance
-            if let scene = UIApplication.shared.connectedScenes.filter({$0.activationState == .foregroundActive}).first as? UIWindowScene {
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene  {
                 super.init(windowScene: scene)
             } else {
                 super.init(frame: UIScreen.main.bounds)

--- a/Source/Infra/EKWindowProvider.swift
+++ b/Source/Infra/EKWindowProvider.swift
@@ -77,7 +77,7 @@ final class EKWindowProvider: EntryPresenterDelegate {
     /** Boilerplate generic setup for entry-window and root-view-controller  */
     private func setupWindowAndRootVC() -> EKRootViewController {
         let entryVC: EKRootViewController
-        if entryWindow == nil {
+        if entryWindow == nil || rootVC == nil {
             entryVC = EKRootViewController(with: self)
             entryWindow = EKWindow(with: entryVC)
             mainRollbackWindow = UIApplication.shared.keyWindow


### PR DESCRIPTION
### Issue Link 🔗
RootVC is null while entryWindow is not null, this causes the app to crash. 

### Goals 🥅
seems like it fixed the issue. 

### Implementation Details ✏️
added a null check 

