### PR TITLE
Fix status bar style

### DIFF
--- a/Source/Model/EntryAttributes/EKAttributes+StatusBar.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+StatusBar.swift
@@ -22,6 +22,9 @@ public extension EKAttributes {
         /** Hidden. Doesn't apply to iPhone X */
         case hidden
         
+        /** Visible with explicit default style */
+        case `default`
+        
         /** Visible with explicit dark style */
         case dark
         
@@ -37,6 +40,8 @@ public extension EKAttributes {
          Note: See *Appearance* */
         public var appearance: Appearance {
             switch self {
+            case .`default`:
+                return (true, .default)
             case .dark:
                 if #available(iOS 13, *) {
                     return (true, .darkContent)
@@ -62,8 +67,10 @@ public extension EKAttributes {
             switch appearance.style {
             case .lightContent:
                 return .light
-            default:
+            case .darkContent:
                 return .dark
+            default:
+                return .`default`
             }
         }
         


### PR DESCRIPTION
### Issue Link 🔗
#369 [StatusBar Style is overwritten by SwiftEntryKit after the alert is dismissed.](https://github.com/huri000/SwiftEntryKit/issues/369)

### Goals 🥅
*What have I tried to achieve / improve + use case example*

### Implementation Details ✏️
add new case `default`

### Testing Details 🔍
*How did I test my implementation*

### Screenshot Links 📷
*Since this a visual project, focusing maily on UI and UX, please attach screenshots in case of UI related change*
