### PR TITLE
Support specified orientations

### DIFF
--- a/Source/Infra/EKRootViewController.swift
+++ b/Source/Infra/EKRootViewController.swift
@@ -66,6 +66,8 @@ class EKRootViewController: UIViewController {
             return super.supportedInterfaceOrientations
         case .all:
             return .all
+        case .specified(let orientation):
+            return orientation
         }
     }
     

--- a/Source/Model/EntryAttributes/EKAttributes+PositionConstraints.swift
+++ b/Source/Model/EntryAttributes/EKAttributes+PositionConstraints.swift
@@ -136,8 +136,11 @@ public extension EKAttributes {
                 /** Uses standard supported interface orientation (target specification in general settings) */
                 case standard
                 
-                /** Supports all orinetations */
+                /** Supports all orientations */
                 case all
+
+                /** Specify orientation mask */
+                case specified(orientation: UIInterfaceOrientationMask)
             }
             
             /** Autorotate the entry along with the device orientation */


### PR DESCRIPTION
### Issue Link 🔗
[Popview show wrong orientation when app force landscape](https://github.com/huri000/SwiftEntryKit/issues/353)

### Goals 🥅
Support specified orientations

### Implementation Details ✏️
I added an extra option to the `SupportedInterfaceOrientation` enum, where you can define the supported orientation mask