### PR TITLE
Use at least one scene even if the conditions are not met

### DIFF
--- a/Source/Infra/EKWindow.swift
+++ b/Source/Infra/EKWindow.swift
@@ -15,7 +15,9 @@ class EKWindow: UIWindow {
     init(with rootVC: UIViewController) {
         if #available(iOS 13.0, *) {
             // TODO: Patched to support SwiftUI out of the box but should require attendance
-            if let scene = UIApplication.shared.connectedScenes.filter({$0.activationState == .foregroundActive}).first as? UIWindowScene {
+            let scenes = UIApplication.shared.connectedScenes
+            let candidateScene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+            if let scene = candidateScene as? UIWindowScene {
                 super.init(windowScene: scene)
             } else {
                 super.init(frame: UIScreen.main.bounds)


### PR DESCRIPTION
### Issue Link 🔗
#377 EKWindow does not appear on the screen in version iOS 13 or later

### Goals 🥅
Makes the EKWindow appear on the screen even when no scene is active.

### Implementation Details ✏️
I've improved it to use at least one scene if there are no candidate scenes.

### Testing Details 🔍
The problematic situation sometimes occurs when you show different types of entries in succession within a short period of time.