### PR TITLE
fix: scroll need check safeAreaInsets

### DIFF
--- a/Source/Infra/EKContentView.swift
+++ b/Source/Infra/EKContentView.swift
@@ -636,7 +636,22 @@ extension EKContentView {
                 let velocity = gr.velocity(in: superview!).y
                 swipeEnded(withVelocity: velocity)
             case .changed:
-                inConstraint.constant += translation
+                var targetConstant = inConstraint.constant + translation
+                if !attributes.scroll.isEdgeCrossingEnabled {
+                    switch attributes.position {
+                    case .top:
+                        let inset = EKWindowProvider.safeAreaInsets.top
+                        if targetConstant > inset {
+                            targetConstant = inset
+                        }
+                    case .bottom, .center:
+                        let inset = EKWindowProvider.safeAreaInsets.bottom
+                        if targetConstant < -inset {
+                            targetConstant = -inset
+                        }
+                    }
+                }
+                inConstraint.constant = targetConstant
             default:
                 break
             }


### PR DESCRIPTION
### Issue Link 🔗
none

### Goals 🥅
Look at the picture. This is a problem caused by edgeCrossingDisabled and pan gestures. I don't think it should exist, but if it is designed like this, please close it.

### Implementation Details ✏️
adjust safeArea by position

### Testing Details 🔍
none

### Screenshot Links 📷
<img width="353" alt="iShot_2022-12-02_12 14 37" src="https://user-images.githubusercontent.com/18711027/205214153-f338e7d1-bfa7-4862-8cce-4bc9949d8c59.png">
