### PR TITLE
Added multilevel window support for stacked presentation

### DIFF
--- a/Source/Infra/EKWindow.swift
+++ b/Source/Infra/EKWindow.swift
@@ -12,7 +12,7 @@ class EKWindow: UIWindow {
     
     var isAbleToReceiveTouches = false
     
-    init(with rootVC: UIViewController) {
+    init(with rootVC: UIViewController, level: UIWindow.Level) {
         if #available(iOS 13.0, *) {
             // TODO: Patched to support SwiftUI out of the box but should require attendance
             if let scene = UIApplication.shared.connectedScenes.filter({$0.activationState == .foregroundActive}).first as? UIWindowScene {
@@ -23,6 +23,7 @@ class EKWindow: UIWindow {
         } else {
             super.init(frame: UIScreen.main.bounds)
         }
+        windowLevel = level
         backgroundColor = .clear
         rootViewController = rootVC
         accessibilityViewIsModal = true
@@ -37,7 +38,7 @@ class EKWindow: UIWindow {
             return super.hitTest(point, with: event)
         }
         
-        guard let rootVC = EKWindowProvider.shared.rootVC else {
+        guard let rootVC = EKWindowProvider.provider(for: windowLevel).rootVC else {
             return nil
         }
         

--- a/Source/SwiftEntryKit.swift
+++ b/Source/SwiftEntryKit.swift
@@ -53,8 +53,8 @@ public final class SwiftEntryKit {
      no entry is currently displayed.
      This can be used
      */
-    public class var window: UIWindow? {
-        return EKWindowProvider.shared.entryWindow
+    public class func window(for level: UIWindow.Level) -> UIWindow? {
+        return EKWindowProvider.provider(for: level).entryWindow
     }
     
     /**
@@ -74,7 +74,7 @@ public final class SwiftEntryKit {
      - parameter name: The name of the entry. Its default value is *nil*.
      */
     public class func isCurrentlyDisplaying(entryNamed name: String? = nil) -> Bool {
-        return EKWindowProvider.shared.isCurrentlyDisplaying(entryNamed: name)
+        return EKWindowProvider.isCurrentlyDisplaying(entryNamed: name)
     }
     
     /**
@@ -93,7 +93,7 @@ public final class SwiftEntryKit {
      - parameter name: The name of the entry. Its default value is *nil*.
      */
     public class func queueContains(entryNamed name: String? = nil) -> Bool {
-        return EKWindowProvider.shared.queueContains(entryNamed: name)
+        return EKWindowProvider.queueContains(entryNamed: name)
     }
     
     /**
@@ -107,7 +107,8 @@ public final class SwiftEntryKit {
      */
     public class func display(entry view: UIView, using attributes: EKAttributes, presentInsideKeyWindow: Bool = false, rollbackWindow: RollbackWindow = .main) {
         DispatchQueue.main.async {
-            EKWindowProvider.shared.display(view: view, using: attributes, presentInsideKeyWindow: presentInsideKeyWindow, rollbackWindow: rollbackWindow)
+            EKWindowProvider.provider(for: attributes.windowLevel.value)
+                .display(view: view, using: attributes, presentInsideKeyWindow: presentInsideKeyWindow, rollbackWindow: rollbackWindow)
         }
     }
     
@@ -122,7 +123,8 @@ public final class SwiftEntryKit {
      */
     public class func display(entry viewController: UIViewController, using attributes: EKAttributes, presentInsideKeyWindow: Bool = false, rollbackWindow: RollbackWindow = .main) {
         DispatchQueue.main.async {
-            EKWindowProvider.shared.display(viewController: viewController, using: attributes, presentInsideKeyWindow: presentInsideKeyWindow, rollbackWindow: rollbackWindow)
+            EKWindowProvider.provider(for: attributes.windowLevel.value)
+                .display(viewController: viewController, using: attributes, presentInsideKeyWindow: presentInsideKeyWindow, rollbackWindow: rollbackWindow)
         }
     }
     
@@ -135,7 +137,7 @@ public final class SwiftEntryKit {
      */
     public class func transform(to view: UIView) {
         DispatchQueue.main.async {
-            EKWindowProvider.shared.transform(to: view)
+            EKWindowProvider.topMostProvider?.transform(to: view)
         }
     }
     
@@ -148,7 +150,7 @@ public final class SwiftEntryKit {
      */
     public class func dismiss(_ descriptor: EntryDismissalDescriptor = .displayed, with completion: DismissCompletionHandler? = nil) {
         DispatchQueue.main.async {
-            EKWindowProvider.shared.dismiss(descriptor, with: completion)
+            EKWindowProvider.dismiss(descriptor, with: completion)
         }
     }
     
@@ -160,10 +162,10 @@ public final class SwiftEntryKit {
      */
     public class func layoutIfNeeded() {
         if Thread.isMainThread {
-            EKWindowProvider.shared.layoutIfNeeded()
+            EKWindowProvider.layoutIfNeeded()
         } else {
             DispatchQueue.main.async {
-                EKWindowProvider.shared.layoutIfNeeded()
+                EKWindowProvider.layoutIfNeeded()
             }
         }
     }


### PR DESCRIPTION
### Issue Link 🔗
[How to display two view the same time by using SwiftEntry ? _#340_](https://github.com/huri000/SwiftEntryKit/issues/340)

### Goals 🥅

Presenting multiple entries on different window levels at the same time.

Entries with the same window level attribute should be presented the same way as before, holding the queue logic same for the same window level. But different window levels should be able to stack on top of each other. Thus creating a window level hierarchy for entries.

### Implementation Details ✏️

EKWindowProvider was a singleton, capable of holding only one window. The window level was being set when the new entry was being prepared to be presented. 

I have removed the shared instance and created a static dictionary which holds the EKWindowProvider instances for different window levels. When the entry is requested to present, if there is a window provider instance present in the dictionary for the window level of that entry (read from it's attributes), that instance is being used for presentation. If not, a new EKWindowProvider instance is being initiated for that window level and being stored in the dictionary. When the last entry for a window level has been dismissed, the provider for that level is also being removed from the dictionary for memory management purposes.

All the presentation and dismissal logic has also been updated accordingly. 

### Testing Details 🔍

I have done some superficial tests and may need deeper testing for any functionalities may have been effected. In my tests, all the basics were working good.

### Screenshot Links 📷
![ezgif-5-b8540dcec3](https://github.com/huri000/SwiftEntryKit/assets/35043995/95e5f593-2eb9-4f7f-a0ce-af322e361d78)
